### PR TITLE
change the default colormap for ctmr_gauss_plot to be RdBu_r

### DIFF
--- a/img_pipe/plotting/ctmr_brain_plot.py
+++ b/img_pipe/plotting/ctmr_brain_plot.py
@@ -29,7 +29,7 @@ import matplotlib as mpl
 
 def ctmr_gauss_plot(tri, vert, color=(0.8, 0.8, 0.8), elecs=None, weights=None,
                     opacity = 1.0, representation='surface', line_width=1.0, gsp = 10,
-                    cmap='RdBu', show_colorbar=True, new_fig=True, vmin=None, vmax=None):
+                    cmap=mpl.cm.get_cmap('RdBu_r'), show_colorbar=True, new_fig=True, vmin=None, vmax=None):
     '''
     ctmr_gauss_plot(tri, vert)
     This function plots the 3D brain surface mesh


### PR DESCRIPTION
change the default colormap for ctmr_gauss_plot to be RdBu_r, the most commonly used colormap.