### PR TITLE
Update setup.py: specify mpl version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name = "img_pipe",
 	  packages = find_packages(),
 	  include_package_data = True,
 	  setup_requires=['cython','numpy','scipy'],
-	  install_requires=['numpy','scipy','pyvtk','mayavi','pymcubes','mne','nibabel','nipy','matplotlib','configparser'],
+	  install_requires=['numpy','scipy','pyvtk','mayavi','pymcubes','mne','nibabel','nipy','matplotlib<2.0.0','configparser'],
 	  dependency_links=['http://www.vtk.org/files/release/6.3/VTK-6.3.0.tar.gz','https://downloads.sourceforge.net/project/pyqt/PyQt4/PyQt-4.12/PyQt4_gpl_mac-4.12.tar.gz?r=&ts=1487961590&use_mirror=superb-sea2'],
 	  cmdclass={'install':MyInstall},
 	  classifiers = [


### PR DESCRIPTION
There is an issue with electrode_picker in mpl 2.0.1, so I am specifying that the mpl version needs to be <2.0.0 until the issue is fixed in mpl 2.0.2 #2 