### PR TITLE
Fixed bug preventing removal of marked electrodes

### DIFF
--- a/img_pipe/SupplementalScripts/electrode_picker.py
+++ b/img_pipe/SupplementalScripts/electrode_picker.py
@@ -750,7 +750,8 @@ class electrode_picker:
         '''
         Remove the electrode at the current crosshair point. 
         '''
-        cs = self.current_slice
+        cs = np.round(self.current_slice).astype(np.int)
+        radius = 2
         if self.bin_mat != '':
             self.bin_mat = ''
             


### PR DESCRIPTION
Using 'u' to remove a marked electrode would result in an error.

Thanks for the great tool!