### PR TITLE
added compatibility for deprecated "raw_input" in python 3

### DIFF
--- a/img_pipe/img_pipe.py
+++ b/img_pipe/img_pipe.py
@@ -24,6 +24,7 @@ from tqdm import tqdm
 import numpy as np
 import scipy.io
 import scipy.spatial
+from six.moves import input
 import matplotlib
 matplotlib.use('Agg')
 from matplotlib import pyplot as plt
@@ -191,7 +192,7 @@ class freeCoG:
         # Check if subj is valid
         if not os.path.isdir(os.path.join(self.subj_dir, self.subj)):
             print('No such subject directory as %s' % (os.path.join(self.subj_dir, self.subj)))
-            ans = raw_input('Would you like to create a new subject directory? (y/N): ')
+            ans = input('Would you like to create a new subject directory? (y/N): ')
             if ans.upper() == 'Y' or ans.upper() == 'YES':
                 os.chdir(self.subj_dir)
                 print("Making subject directory")
@@ -652,11 +653,11 @@ class freeCoG:
             # project the electrodes to the convex hull of the pial surface
             print('Projection direction vector: ', direction)
         else:
-            proj_direction = raw_input('Enter a custom projection direction as a string (lh,rh,top,bottom,front,back,or custom): If none provided, will default to hemisphere: \n')
+            proj_direction = input('Enter a custom projection direction as a string (lh,rh,top,bottom,front,back,or custom): If none provided, will default to hemisphere: \n')
             if proj_direction == 'custom':
-                x = raw_input('Enter projection vector\'s x-component: \n')
-                y = raw_input('Enter projection vector\'s y-component: \n')
-                z = raw_input('Enter projection vector\'s z-component: \n')
+                x = input('Enter projection vector\'s x-component: \n')
+                y = input('Enter projection vector\'s y-component: \n')
+                z = input('Enter projection vector\'s z-component: \n')
                 direction = [float(x),float(y),float(z)]
             elif proj_direction not in ['lh','rh','top','bottom','front','back','custom']:
                 direction = self.hem
@@ -967,26 +968,26 @@ class freeCoG:
         else: #interactive
             done = False
             while done == False:
-                num_empty_rows = raw_input('Are you adding a row that will be NaN in the elecmatrix? If not, press enter. If so, enter the number of empty rows to add: \n')
+                num_empty_rows = input('Are you adding a row that will be NaN in the elecmatrix? If not, press enter. If so, enter the number of empty rows to add: \n')
                 if len(num_empty_rows):
                     num_empty_rows = int(num_empty_rows)
-                    short_name_prefix = raw_input('What is the short name prefix (e.g. G, AD, HD)?\n')
+                    short_name_prefix = input('What is the short name prefix (e.g. G, AD, HD)?\n')
                     short_names.extend([short_name_prefix for i in range(1,num_empty_rows+1)])
-                    long_name_prefix = raw_input('What is the long name prefix (e.g. L256Grid, HippocampalDepth)?\n')
+                    long_name_prefix = input('What is the long name prefix (e.g. L256Grid, HippocampalDepth)?\n')
                     long_names.extend([long_name_prefix for i in range(1,num_empty_rows+1)])
-                    elec_type = raw_input('What is the type of the device (e.g. grid, strip, depth)?\n')
+                    elec_type = input('What is the type of the device (e.g. grid, strip, depth)?\n')
                     elec_types.extend([elec_type for i in range(num_empty_rows)])
                     elecmatrix_all.append(np.ones((num_empty_rows,3))*np.nan)
                 else:
-                    short_name_prefix = raw_input('What is the short name prefix of the device (e.g. G, AD, HD)?\n')
-                    long_name_prefix = raw_input('What is the long name prefix of the device? (e.g. L256Grid, HippocampalDepth)\n')
-                    elec_type = raw_input('What is the type of the device? (e.g. grid, strip, depth)\n')     
+                    short_name_prefix = input('What is the short name prefix of the device (e.g. G, AD, HD)?\n')
+                    long_name_prefix = input('What is the long name prefix of the device? (e.g. L256Grid, HippocampalDepth)\n')
+                    elec_type = input('What is the type of the device? (e.g. grid, strip, depth)\n')     
                     try:
-                        file_name = raw_input('What is the filename of the device\'s electrode coordinate matrix?\n')
+                        file_name = input('What is the filename of the device\'s electrode coordinate matrix?\n')
                         indiv_file = os.path.join(self.elecs_dir,'individual_elecs', file_name)
                         elecmatrix = scipy.io.loadmat(indiv_file)['elecmatrix']
                     except IOError:
-                        file_name = raw_input('Sorry, that file was not found. Please enter the correct filename of the device: \n ')
+                        file_name = input('Sorry, that file was not found. Please enter the correct filename of the device: \n ')
                         indiv_file = os.path.join(self.elecs_dir,'individual_elecs', file_name)
                         elecmatrix = scipy.io.loadmat(indiv_file)['elecmatrix']
                     num_elecs = elecmatrix.shape[0]
@@ -994,10 +995,10 @@ class freeCoG:
                     short_names.extend([short_name_prefix+str(i) for i in range(1,num_elecs+1)])
                     long_names.extend([long_name_prefix+str(i) for i in range(1,num_elecs+1)])
                     elec_types.extend([elec_type for i in range(num_elecs)])
-                completed = raw_input('Finished entering devices? Enter \'y\' if finished.')
+                completed = input('Finished entering devices? Enter \'y\' if finished.')
                 if completed=='y':
                     done = True 
-            outfile = raw_input('What filename would you like to save out to?\n')
+            outfile = input('What filename would you like to save out to?\n')
         elecmatrix_all = np.vstack(elecmatrix_all)
         eleclabels = np.ones(elecmatrix_all.shape,dtype=np.object)
         eleclabels[:,0] = short_names


### PR DESCRIPTION
I received an error when trying to run the pipeline with python3 due to deprecation of `raw_input`. 

Here is a suggested fix that worked for me, using six for backwards compatibility with python2. 

Thanks for the pipeline! 